### PR TITLE
SCF-33: Calendar bookmarked club filter and tag filter fix

### DIFF
--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -28,7 +28,7 @@ function Calendar({ student, tagOptions, state}) {
     majors: [],
     minors: [],
     interests: [],
-    favorited_clubs: ['Karasuno High VBC', 'User Testing'],
+    bookmarked_clubs: ['sproul.club', 'maybe club'],
     visited_clubs: [],
     club_board: {
       interested_clubs: [
@@ -376,15 +376,20 @@ function Calendar({ student, tagOptions, state}) {
     if ((tags !== null) && (tags.length !== 0)) {
       eventsList = eventsList.filter((event) => {
         let tagExists = false;
-        tags.forEach((t) => {
-          tagExists = event.club.tags.includes(t.label);
-        });
+        for (let i = 0; i < tags.length; i++) {
+          tagExists = event.club.tags.includes(tags[i].label);
+          if (tagExists) {break;}
+        }
         return tagExists;
       });
     }
 
     if ((recruiting !== null) && (recruiting.length !== 0)) {
       eventsList = eventsList.filter((event) => event.club.recruiting === recruiting.label);
+    }
+
+    if (bookmarked) {
+      eventsList = eventsList.filter((event) => student.bookmarked_clubs.includes(event.club.name));
     }
     return eventsList
   }

--- a/src/pages/student/Dashboard.js
+++ b/src/pages/student/Dashboard.js
@@ -60,7 +60,7 @@ function Dashboard({ student }) {
     majors: [],
     minors: [],
     interests: [],
-    favorited_clubs: ['Karasuno High VBC', 'User Testing'],
+    bookmarked_clubs: ['sproul.club', 'maybe club'],
     visited_clubs: [],
     recommended_clubs: [
       {


### PR DESCRIPTION
- added bookmarked filter logic on dashboard calendar
- fixed tag filter to be OR instead of AND
> Ex: filter with tags "Computer Science" and "Consulting" were only showing clubs that have both tags rather than one or the other