### PR TITLE
SCF-58: Dropdown filters should allow for more than 3 selections

### DIFF
--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -233,10 +233,7 @@ function Calendar({ student, tagOptions, state}) {
       fontWeight: 300,
       fontStyle: 'normal',
       textAlign: 'left',
-      color:
-        state.selectProps.value && state.selectProps.value.length >= 3
-          ? '#cccccc'
-          : '#4e4e4e',
+      color:'#4e4e4e',
     }),
     multiValueRemove: (provided, state) => ({
       ...provided,
@@ -418,6 +415,7 @@ function Calendar({ student, tagOptions, state}) {
           <Dropdown
             options={clubOptions}
             multi={true}
+            infinite={true}
             search={true}
             placeholder="Select clubs"
             style={customStyles}
@@ -428,8 +426,9 @@ function Calendar({ student, tagOptions, state}) {
           <Dropdown
             options={tagOptions}
             multi={true}
+            infinite={true}
             search={true}
-            placeholder="Select tags (maximum 3 tags)"
+            placeholder="Select tags"
             style={customStyles}
             defaultValue={tags}
             set={setTags}

--- a/src/components/layout/dropdown/Dropdown.js
+++ b/src/components/layout/dropdown/Dropdown.js
@@ -2,10 +2,11 @@ import React from 'react';
 import Select from 'react-select';
 
 const handleChange = (value, props) => {
+  var infinite = props.infinite || false;
   if (props.multi) {
     if (value && value.length >= 3) {
       // recolor option text to light grey, to look unclickable :'(
-      if (value.length > 3) {
+      if (value.length > 3 && !infinite) {
         value.pop();                        // remove 4th tag
         // commented out below two lines bc i wasn't sure what they do oop
         // props.errorPopup('tagOverflow');    // make popup visible for ~2s


### PR DESCRIPTION
[SCF-58:](https://scfrontend.atlassian.net/browse/SCF-58?atlOrigin=eyJpIjoiNGVkODBiYTAzMDVhNGNlZTlmNmQzY2EyN2Q4ZDUwYmMiLCJwIjoiaiJ9) Dropdown filters should allow for more than 3 selections

Steps to test: 
1. Verify filters for calendar allow more than 3 selections for each filter

Screenshot:

![image](https://user-images.githubusercontent.com/47483517/140532006-5826b2d0-a866-4e83-b8e2-4064da19f0a0.png)
