### PR TITLE
[SCF-45] [Calendar] Make entire event bar clickable

### DIFF
--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -449,16 +449,16 @@ function Calendar({ student, tagOptions, state}) {
         </div>
       </div>
       <RBC
-        views={["month"]}
-        localizer={localizer}
-        events={createCalendarEventsList()}
         components={{event: CalendarEvent}}
-        startAccessor="start"
         endAccessor="end"
-        style={{ height: 700 }}
+        eventPropGetter={eventStyleGetter}
+        events={createCalendarEventsList()}
+        localizer={localizer}
         messages={{next:"▶",previous:"◀"}}
         popup
-        eventPropGetter={eventStyleGetter}
+        startAccessor="start"
+        style={{ height: 700 }}
+        views={["month"]}
       />    
     </div>
     

--- a/src/components/calendar/Calendar.scss
+++ b/src/components/calendar/Calendar.scss
@@ -112,6 +112,10 @@
 
 .rbc-event{
     padding: 3px 5px;
+    background: inherit;
+    &:hover {
+        filter: brightness(.85);
+    }
 }
 
 .rbc-event-content{
@@ -126,7 +130,7 @@
 .rbc-event-content-inner{
     display: flex;
     align-items: center;
-    cursor: default;
+    cursor: pointer;
 }
 
 .rbc-event-content img {

--- a/src/components/calendar/Calendar.scss
+++ b/src/components/calendar/Calendar.scss
@@ -112,10 +112,6 @@
 
 .rbc-event{
     padding: 3px 5px;
-    background: inherit;
-    &:hover {
-        filter: brightness(.85);
-    }
 }
 
 .rbc-event-content{

--- a/src/components/calendar/CalendarEvent.js
+++ b/src/components/calendar/CalendarEvent.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import Popover from '@material-ui/core/Popover';
-import Button from '@material-ui/core/Button';
-import { makeStyles } from '@material-ui/core/styles';
 import Moment from 'react-moment';
 import { simplestRangeFormat, START_DATETIME, END_DATETIME } from '../../utils/formatTimeAndDate';
 import './CalendarEvent.scss';
@@ -20,8 +18,8 @@ function CalendarEvent ({event}) {
     const open = Boolean(anchorEl);
     const id = open ? 'simple-popover' : undefined;
     return (
-        <div className="rbc-event-content-inner">
-            <div >
+        <div>
+            <div className="rbc-event-content-inner" onClick={handleClick}>
                 <img src={event.icon.toString()}/>
                 {event.title.toString()}
             </div>
@@ -33,11 +31,11 @@ function CalendarEvent ({event}) {
                 onClose={handleClose}
                 anchorOrigin={{
                 vertical: 'bottom',
-                horizontal: 'center',
+                horizontal: 'left',
                 }}
                 transformOrigin={{
                 vertical: 'top',
-                horizontal: 'center',
+                horizontal: 'left',
                 }}
             >
                 <div className="popover-wrapper">

--- a/src/components/calendar/CalendarEvent.js
+++ b/src/components/calendar/CalendarEvent.js
@@ -6,16 +6,7 @@ import Moment from 'react-moment';
 import { simplestRangeFormat, START_DATETIME, END_DATETIME } from '../../utils/formatTimeAndDate';
 import './CalendarEvent.scss';
 
-const useStyles = makeStyles((theme) => ({
-    button: {
-        padding: 0,
-        fontFamily: 'Qanelas Soft',
-        textTransform: "none"
-      },
-  }));
-
 function CalendarEvent ({event}) {
-    const classes = useStyles();
     const [anchorEl, setAnchorEl] = React.useState(null);
 
     const handleClick = (event) => {
@@ -30,47 +21,44 @@ function CalendarEvent ({event}) {
     const id = open ? 'simple-popover' : undefined;
     return (
         <div className="rbc-event-content-inner">
-            <div>
-                <Button className={classes.button} onClick={handleClick}>
-                    <img src={event.icon.toString()}/>
-                    {event.title.toString()}
-                </Button>
-
-                <Popover
-                    id={id}
-                    open={open}
-                    anchorEl={anchorEl}
-                    onClose={handleClose}
-                    anchorOrigin={{
-                    vertical: 'bottom',
-                    horizontal: 'center',
-                    }}
-                    transformOrigin={{
-                    vertical: 'top',
-                    horizontal: 'center',
-                    }}
-                >
-                    <div className="popover-wrapper">
-                        <div className="popover-flex-left"><img src={event.icon.toString()}/></div>
-                        <div className="popover-flex-right">
-                            <div className="popover-event-title">{event.title}</div>
-                            <div className="popover-event-times"> 
-                                <Moment
-                                interval={0}
-                                date={event.start}
-                                format={simplestRangeFormat(event.start, event.end, START_DATETIME)}/>
-                                {" - "}
-                                <Moment
-                                interval={0}
-                                date={event.end}
-                                format={simplestRangeFormat(event.start, event.end, END_DATETIME)} />
-                            </div>
-                            <div className="popover-event-description">{event.description}</div>
-                        </div>
-                    </div>
-                </Popover>
+            <div >
+                <img src={event.icon.toString()}/>
+                {event.title.toString()}
             </div>
             
+            <Popover
+                id={id}
+                open={open}
+                anchorEl={anchorEl}
+                onClose={handleClose}
+                anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'center',
+                }}
+                transformOrigin={{
+                vertical: 'top',
+                horizontal: 'center',
+                }}
+            >
+                <div className="popover-wrapper">
+                    <div className="popover-flex-left"><img src={event.icon.toString()}/></div>
+                    <div className="popover-flex-right">
+                        <div className="popover-event-title">{event.title}</div>
+                        <div className="popover-event-times"> 
+                            <Moment
+                            interval={0}
+                            date={event.start}
+                            format={simplestRangeFormat(event.start, event.end, START_DATETIME)}/>
+                            {" - "}
+                            <Moment
+                            interval={0}
+                            date={event.end}
+                            format={simplestRangeFormat(event.start, event.end, END_DATETIME)} />
+                        </div>
+                        <div className="popover-event-description">{event.description}</div>
+                    </div>
+                </div>
+            </Popover>            
         </div>
     )
 }


### PR DESCRIPTION
The gif does a poor job of showing this, because I happened to click on the image every time, but the entire event bar should now be clickable. When you hover over an event, the background color should darken to indicate that it is clickable.

Steps to test:
* Click on different parts of the calendar event bar.
* Ensure that clicking on any part of the bar will show the event popover displaying more information about the event.

![calendar  scf-45 entire event bar clickable](https://user-images.githubusercontent.com/40283466/140929115-bb0ba160-160d-4dcc-8105-b828d712addf.gif)

_**Known issue:**_ If an event spans more than one week, only the event bar of the row where the mouse is hovering will darken. It would be nice if the entire event (could span more than one week) would darken. See the "Virtual Tabling" event in pink in the gif for an example (or ping @tankaren to clarify). @timoteayang would be cool if you could investigate this and how tough it'll be to fix. From what I can tell, it's because there's two different classes for it: .rbc-event-continues-after and  .rbc-event-continues-prior