### PR TITLE
SCF-69 Reset Password Success Image Off Center

### DIFF
--- a/src/pages/clubLogin/ResetPassword.css
+++ b/src/pages/clubLogin/ResetPassword.css
@@ -26,7 +26,6 @@
 }
 
 .recover .form .imgContainer.two img {
-  padding-left: 65px;
   height: 160px;
 }
 


### PR DESCRIPTION
SCF-69 I just removed the padding on the second reset password image which the first one did not have, and that's why it was off-centered. 
<img width="547" alt="Screen Shot 2021-11-09 at 2 02 41 PM" src="https://user-images.githubusercontent.com/21046037/141012920-01562d18-1671-400d-a076-e222fe238c40.png">
