### PR TITLE
SCF-78 Moved Gallery Above About

### DIFF
--- a/src/pages/club/ClubPage.js
+++ b/src/pages/club/ClubPage.js
@@ -166,6 +166,30 @@ function ClubPage({
 
   const overview = (
     <div>
+      <div className="bottomGallery">
+        {((organization.gallery_media &&
+          organization.gallery_media.length > 0) ||
+          admin) && (
+          <div className="clubpage-content-gallery">
+            <div className="clubpage-content-header">
+              <h1>Gallery (Beta)</h1>
+              {admin && (
+                <img
+                  src={require('../assets/Edit.svg').default}
+                  className="clubpage-content-header-icon"
+                  onClick={() => setShowGalleryModal(admin)}
+                />
+              )}
+            </div>
+            {organization.gallery_media &&
+              organization.gallery_media.length > 0 && (
+                <div className="gallery">
+                  <Gallery data={organization.gallery_media} />
+                </div>
+              )}
+          </div>
+        )}
+      </div>
       <div>
         {
           <div
@@ -201,30 +225,6 @@ function ClubPage({
           {aboutMore ? 'See less' : 'See more'}{' '}
           {aboutMore ? <ExpandLess /> : <ExpandMoreIcon />}{' '}
         </button>
-        <div className="bottomGallery">
-          {((organization.gallery_media &&
-            organization.gallery_media.length > 0) ||
-            admin) && (
-            <div className="clubpage-content-gallery">
-              <div className="clubpage-content-header">
-                <h1>Gallery (Beta)</h1>
-                {admin && (
-                  <img
-                    src={require('../assets/Edit.svg').default}
-                    className="clubpage-content-header-icon"
-                    onClick={() => setShowGalleryModal(admin)}
-                  />
-                )}
-              </div>
-              {organization.gallery_media &&
-                organization.gallery_media.length > 0 && (
-                  <div className="gallery">
-                    <Gallery data={organization.gallery_media} />
-                  </div>
-                )}
-            </div>
-          )}
-        </div>
         {/* <GridComponent displayBanner= {true}/> */}
       </div>
     </div>


### PR DESCRIPTION
SCF-78 I moved the gallery component above the about section
<img width="476" alt="Screen Shot 2021-12-03 at 5 20 30 AM" src="https://user-images.githubusercontent.com/21046037/144611154-cf887669-a1a9-42fa-812e-589d63346dbe.png">

